### PR TITLE
chore: Remove duplicated fire dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ loralib
 black
 black[jupyter]
 datasets
-fire
 peft
 transformers>=4.34.1
 sentencepiece


### PR DESCRIPTION
`fire` is mentioned twice in the requirements.txt. This removes it.